### PR TITLE
feat(ui): Apple Calendar settings UX improvements and docs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -10,6 +10,8 @@ navigation:
         path: ./pages/sdks.mdx
       - page: CLI
         path: ./pages/cli.mdx
+      - page: Apple Calendar
+        path: ./pages/apple-calendar.mdx
   - api: API Reference
     snippets:
       typescript: "@move37/sdk"

--- a/fern/pages/apple-calendar.mdx
+++ b/fern/pages/apple-calendar.mdx
@@ -1,0 +1,43 @@
+---
+title: Apple Calendar
+description: Connect your iCloud calendar to Move37 so tasks can be scheduled and tracked alongside your existing events.
+---
+
+## What the integration does
+
+Move37 syncs with your Apple Calendar via CalDAV. Once connected, Move37 can read your existing events to understand your availability and write scheduled tasks back to a calendar of your choosing — keeping everything in one place without leaving your native calendar app.
+
+## Before you connect
+
+Apple requires an **app-specific password** to allow third-party apps like Move37 to access your iCloud account. Your main Apple ID password will not work.
+
+To generate one:
+
+1. Go to [account.apple.com](https://account.apple.com) and sign in.
+2. Under the **Sign-In and Security** section, choose **App-Specific Passwords**.
+3. Click the **+** button, give the password a label (e.g. "Move37"), and click **Create**.
+4. Copy the password — it is only shown once.
+
+Apple's own guide is available at [support.apple.com/en-us/102654](https://support.apple.com/en-us/102654).
+
+## Connecting via the settings panel
+
+1. Open Move37 and click the **gear icon** (⚙) in the top-right corner to open the settings panel.
+2. Under **Apple Calendar**, click **Connect**.
+3. Enter your **Apple ID email** (the address you use to sign in to iCloud).
+4. Paste the **app-specific password** you generated above.
+5. The **CalDAV URL** defaults to `https://caldav.icloud.com` — leave this unchanged unless your organisation uses a custom CalDAV server.
+6. Click **Connect**. Move37 will verify your credentials and list your available calendars.
+
+## Selecting a writable calendar
+
+After connecting, Move37 will display the calendars associated with your account. Choose the one you want Move37 to write scheduled tasks to. You can change this selection at any time from the same settings panel.
+
+## Disconnecting
+
+To remove the integration:
+
+1. Open the settings panel via the gear icon.
+2. Under **Apple Calendar**, click **Disconnect**.
+
+Move37 will immediately stop syncing and remove your stored credentials. Events already written to your calendar are not deleted.

--- a/src/move37/web/src/App.jsx
+++ b/src/move37/web/src/App.jsx
@@ -180,16 +180,9 @@ function formatSchedulingCode(code) {
 
 function SettingsIcon() {
   return (
-    <svg viewBox="0 0 24 24" aria-hidden="true">
-      <circle cx="12" cy="12" r="2.7" className="icon-globe-outline" />
-      <path d="M12 4.7v2.2" className="icon-map-line" />
-      <path d="M12 17.1v2.2" className="icon-map-line" />
-      <path d="M19.3 12h-2.2" className="icon-map-line" />
-      <path d="M6.9 12H4.7" className="icon-map-line" />
-      <path d="M17.2 6.8l-1.5 1.5" className="icon-map-line" />
-      <path d="M8.3 15.7l-1.5 1.5" className="icon-map-line" />
-      <path d="M17.2 17.2l-1.5-1.5" className="icon-map-line" />
-      <path d="M8.3 8.3L6.8 6.8" className="icon-map-line" />
+    <svg viewBox="0 0 24 24" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
     </svg>
   );
 }
@@ -4065,7 +4058,20 @@ export default function App() {
                     />
                   </label>
                   <p className="small">
-                    For iCloud, use an app-specific password from your Apple account security settings.
+                    Generate your password from account.apple.com{" "}
+                    <a
+                      href="https://support.apple.com/en-us/102654"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label="How to generate an app-specific password (opens in new tab)"
+                      style={{ display: "inline-flex", alignItems: "center", gap: "2px", color: "inherit" }}
+                    >
+                      <svg viewBox="0 0 16 16" aria-hidden="true" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" style={{ width: "0.9em", height: "0.9em", flexShrink: 0 }}>
+                        <path d="M7 3H3a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h9a1 1 0 0 0 1-1V9" />
+                        <path d="M10 2h4v4" />
+                        <path d="M14 2 8 8" />
+                      </svg>
+                    </a>
                   </p>
                   <div className="sheet-actions">
                     <button type="button" className="ghost-button" onClick={closeSettingsModal}>


### PR DESCRIPTION
## Summary
- Replaces the sun/radial-lines icon with a standard gear/cog SVG in `SettingsIcon`
- Updates the iCloud helper text to "Generate your password from account.apple.com" with an inline external-link icon pointing to https://support.apple.com/en-us/102654 (opens in new tab)
- Adds `fern/pages/apple-calendar.mdx` covering the full connection flow (what the integration does, generating an app-specific password, connecting, selecting a calendar, disconnecting)
- Registers the new page under the Overview section in `fern/docs.yml`

Closes #29

## Test plan
- [ ] Settings button shows a recognisable gear/cog icon
- [ ] Apple Calendar settings panel displays the new helper text with a working external link
- [ ] `fern/pages/apple-calendar.mdx` exists and reads correctly
- [ ] Page appears in `fern/docs.yml` under Overview
- [ ] Connect/disconnect flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)